### PR TITLE
shell-lg: Autocomplete and some other things

### DIFF
--- a/shell-lg
+++ b/shell-lg
@@ -21,6 +21,20 @@ restore_terminal() {
     tput reset
 }
 
+eval_javascript_in_gnome_shell_gdbus() {
+    RET=$(gdbus call --session                       \
+               --dest org.gnome.Shell                \
+               --object-path /org/gnome/Shell        \
+               --method org.gnome.Shell.Eval         \
+	       "$1")
+    if [[ "$RET" =~ ^\(false,.* ]]; then
+        echo $RET > /dev/stderr
+        return 1
+    else
+        echo "$RET" | sed -e 's/(true, ."\?\([^"]*\)"\?.)/\1/'
+    fi
+}
+
 eval_javascript_in_gnome_shell() {
     json=$(mktemp)
     busctl call --user --json=short               \
@@ -159,7 +173,55 @@ check_for_unsafe_mode() {
     fi
 }
 
+eval_autocomplete_javascript() {
+    TEXT="$1"
+    OUTPUT=$(eval_javascript_in_gnome_shell_gdbus "
+        const AsyncFunction = async function () {}.constructor;
+
+        const command = \`
+            const JsParse = await import('resource:///org/gnome/shell/misc/jsParse.js');
+	    const commandHeader = \\\\\`
+		const {Clutter, Gio, GLib, GObject, Meta, Shell, St} = imports.gi;
+		const Main = await import('resource:///org/gnome/shell/ui/main.js');
+		const inspect = Main.lookingGlass.inspect.bind(Main.lookingGlass);
+		const it = Main.lookingGlass.getIt();
+		const r = Main.lookingGlass.getResult.bind(Main.lookingGlass);
+	    \\\\\`;
+
+	    const completions = await JsParse.getCompletions('$TEXT', commandHeader, []);
+	    return {
+	        'completions': completions[0],
+		'attrHead': completions[1]
+	    };\`;
+	AsyncFunction(command)();
+    ")
+    if [ $? = 1 ]; then
+	echo fail
+    fi
+    echo "$OUTPUT" | sed -e "s/(true, '\(.*\)')$/\1/"
+}
+
+
+autocomplete() {
+    RESULT="$(eval_autocomplete_javascript "$READLINE_LINE")"
+    COMPLETIONS="$(echo "$RESULT" | jq '.completions[]' | sed 's/\"//g')"
+    ATTR_HEAD=$(echo "$RESULT" | jq '.attrHead' | sed 's/\"//g')
+    N_COMPLETIONS=$(echo "$COMPLETIONS" | wc -w)
+    if [ $N_COMPLETIONS = 0 ]; then
+	return
+    elif [ $N_COMPLETIONS = 1 ]; then
+	TO_ADD=$(echo $COMPLETIONS | sed s/$ATTR_HEAD//)
+	READLINE_LINE+="$TO_ADD"
+	(( READLINE_POINT += $(echo "$TO_ADD" | wc -c) ))
+    else
+	echo "$COMPLETIONS" | columns
+    fi
+}
+
 main_loop() {
+    if [ -t 1 ] && [ $MODE = simple ]; then
+	bind -x '"\t"':autocomplete 2> /dev/null
+    fi
     while true; do
         ask_user_for_input
         eval_javascript_in_looking_glass "$input_buffer"

--- a/shell-lg
+++ b/shell-lg
@@ -75,11 +75,13 @@ eval_javascript_in_looking_glass() {
 
     eval_javascript_in_gnome_shell "delete Main.lookingGlass._lastEncodedResult;" > /dev/null
 
-    echo ">>> $1"
+    if [ $MODE = tui ]; then
+	echo ">>> $1"
+    fi
     echo "${OUTPUT}"
 }
 
-ask_user_for_input() {
+draw_prompt_tui() {
     # Save cursor position
     tput sc
 
@@ -107,9 +109,35 @@ ask_user_for_input() {
     tput rc
 }
 
+draw_prompt_simple() {
+    read -p ">>> " -re input
+    if [ $? = 1 ]; then
+        exit
+    fi
+
+    [ $? != 0 ] && continue
+
+    if [ "$input" = "quit" -o "$input" = "q" -o "$input" = "exit" ]; then
+        exit
+    fi
+
+    # Save input to history
+    history -s "$input"
+}
+
+ask_user_for_input() {
+    if [ $MODE = tui ]; then
+	draw_prompt_tui
+    else
+	draw_prompt_simple
+    fi
+}
+
 quit_message() {
-    # Move to just below the prompt
-    tput cup $(($(tput lines) - PROMPT_LINES + 1)) 0
+    if [ $MODE = tui ]; then
+	# Move to just below the prompt
+	tput cup $(($(tput lines) - PROMPT_LINES + 1)) 0
+    fi
 
     echo -ne "Type quit to exit"
     ask_user_for_input
@@ -139,10 +167,21 @@ main_loop() {
 
 check_for_unsafe_mode
 
-trap 'quit_message' SIGINT
-trap restore_terminal EXIT
+if [ "$1" = "--notui" ]; then
+    export MODE=simple
+else
+    export MODE=tui
+fi
 
-init_terminal
-load_history
+trap 'quit_message' SIGINT
+
+if [ $MODE = tui ]; then
+    init_terminal
+    load_history
+fi
+
 main_loop
-restore_terminal
+
+if [ $MODE = tui ]; then
+    restore_terminal
+fi

--- a/shell-lg
+++ b/shell-lg
@@ -47,6 +47,7 @@ eval_javascript_in_looking_glass() {
 
     eval_javascript_in_gnome_shell "
         const GLib = imports.gi.GLib;
+        Main.createLookingGlass();
         const results = Main.lookingGlass._resultsArea;
         Main.lookingGlass._entry.text = '${ENCODED_TEXT}'.replace(/([0-9a-fA-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)));
         Main.lookingGlass._entry.clutter_text.activate();


### PR DESCRIPTION
* No-tui mode, to avoid making it covering the terminal. Useful if one wants to look at the output after having exited
* ^D to exit, for convenience.
* Autocomplete when in no-tui mode. Autocompletes if there is only one alternative, otherwise it'll list all alternatives directly