### PR TITLE
fixing issue with md link rendering

### DIFF
--- a/markdown-render.py
+++ b/markdown-render.py
@@ -64,11 +64,13 @@ class MarkdownRenderer(mistune.HTMLRenderer):
             table_of_contents.append(f"{indent}- {heading['text']}")
         return '\n'.join(table_of_contents)
 
-    def link(self, text, url, title):
+    def link(self, url, text, title):
         if self.strip_links:
             return text
+        elif title:
+            return f"[{text}]({url} \"{title}\")"
         else:
-            return f"{text} <{url}>"
+            return f"[{text}]({url})"
 
     def list(self, body, ordered, level, start):
         indent = '  ' * (level - 1)


### PR DESCRIPTION
the ordering of the link and url arguments was wrong so they were getting rendered in the wrong spot. also the function didn't handle when there is a title vs no title.